### PR TITLE
resolved dungeon loot problem

### DIFF
--- a/LootSpecHelper.lua
+++ b/LootSpecHelper.lua
@@ -67,6 +67,8 @@ keyLevels = {
     "20+"
 }
 
+firstLoading = true
+
 function SlashCmdList.LOOTSPECHELPER(msg, editbox)
     if strtrim(msg) == "enable" then
         disabled = false;
@@ -249,7 +251,12 @@ function determineDungeonDropsForLootSpecs(current_lsh_instanceName)
             table.remove( specTables[1], removalCounter )
         end
         C_Timer.After(0.1, function()
-            displaySpecLoot(specTables, sharedLoot, "dungeon")
+            if(firstLoading) then
+                firstLoading = false
+                determineDungeonDropsForLootSpecs(current_lsh_instanceName)
+            else
+                displaySpecLoot(specTables, sharedLoot, "dungeon")
+            end
         end)
     end
     if EncounterJournal ~= nil then

--- a/LootSpecHelper.toc
+++ b/LootSpecHelper.toc
@@ -1,7 +1,7 @@
 ## Interface: 100105
 ## Title: LootSpecHelper
 ## Author: Van
-## Version: 1.5
+## Version: 1.6
 ##SavedVariablesPerCharacter: targetedItemsRaid, targetedItemsDungeon
 ## IconTexture: Interface\AddOns\LootSpecHelper\Media\Icons\lshIcon.jpeg
 


### PR DESCRIPTION
resolved dungeon problem on first login that would cause dungeon spec to show as shared spec even if it was only a single spec item