### PR TITLE
v2.0

### DIFF
--- a/LootSpecHelper.lua
+++ b/LootSpecHelper.lua
@@ -48,6 +48,7 @@ notLoadedItems = {};
 
 encounterLoadedStatus = {}
 
+-- UPDATE step 6: update key levels if they change
 keyLevels = {
     "2",
     "3",
@@ -67,14 +68,25 @@ keyLevels = {
     "17",
     "18",
     "19",
-    "20+"
+    "20+",
+    "6/6 Hero (483)",
+    "4/4 Vault (489)"
 }
+
+runningTargetedKey = false;
 
 function SlashCmdList.LOOTSPECHELPER(msg, editbox)
     if strtrim(msg) == "enable" then
         disabled = false;
         mostRecentBoss = nil;
         print("LootSpecHelper enabled")
+    elseif strtrim(msg) == "disable" then
+        disabled = true;
+        print("LootSpecHelper disabled")
+    elseif strtrim(msg) == "reset" then
+        disabled = false;
+        mostRecentBoss = nil;
+        print("LootSpecHelper reset")
     else
         LootSpecHelperEventFrame:CreateLootSpecHelperWindow();
     end
@@ -168,6 +180,8 @@ function determineDungeonDropsForLootSpecs(current_lsh_instanceName)
         lsh_Off()
     end
     EJ_SelectTier(latestTierIndex)
+
+    -- targetedInstanceId = this index
     while true do
         local lsh_instanceID, lsh_dungeon_instance_name = EJ_GetInstanceByIndex(index, false)
         if not instanceID then break end
@@ -179,10 +193,12 @@ function determineDungeonDropsForLootSpecs(current_lsh_instanceName)
     end
     if targetedInstanceId ~= nil then
     
-        local function targetingItem(passedItemId)
+        --check if I am targeting the item with the passed ID
+        local function targetingItem(passedItemName)
             for k, v in pairs(targetedItemsDungeon) do
-                if v["itemId"] == passedItemId then
-                    return v["name"]
+                if v["name"] == passedItemName then
+                    local item = Item:CreateFromItemID(v["itemId"])
+                    return v["itemId"]
                 end
             end
             return nil;
@@ -192,18 +208,22 @@ function determineDungeonDropsForLootSpecs(current_lsh_instanceName)
         local lsh_class_id = select(3,UnitClass('player'))
         local lsh_numSpecializations = GetNumSpecializationsForClassID(lsh_class_id)
         local specTables = {};
+
         -- get the targeted items for each spec
         for lsh_specFilter = 1, lsh_numSpecializations, 1 do
             local lsh_currentTable = {};
             lsh_spec_id, lsh_name = GetSpecializationInfo(lsh_specFilter)
             EJ_SetLootFilter(lsh_class_id, lsh_spec_id)
+            C_EncounterJournal.ResetSlotFilter()
+            EJ_SetDifficulty(8) -- 8 is the difficulty for m+
 
             index = 1
             while true do
                 local itemId = C_EncounterJournal.GetLootInfoByIndex(index);
                 if not itemId then break end
-                if targetingItem(itemId["itemID"]) then
-                    table.insert(lsh_currentTable, itemId["itemID"])
+                -- handle the item
+                if targetingItem(itemId["name"]) then
+                    table.insert(lsh_currentTable, itemId["name"])
                 end
                 index = index + 1
             end
@@ -241,6 +261,8 @@ function determineDungeonDropsForLootSpecs(current_lsh_instanceName)
                 end
             end
         end
+        
+        --remove shared from all the other tables
         for k,v in pairs(sharedLoot) do
             local removalCounter = 1
             for _,value in pairs(specTables[1]) do
@@ -265,7 +287,6 @@ function determineDungeonDropsForLootSpecs(current_lsh_instanceName)
     end
 end
 
-
 function LootSpecHelperEventFrame:onLoad()
 	AceGUI = LibStub("AceGUI-3.0");
 	LootSpecHelperEventFrame:RegisterEvent("PLAYER_TARGET_CHANGED")
@@ -275,6 +296,46 @@ function LootSpecHelperEventFrame:onLoad()
 	LootSpecHelperEventFrame:RegisterEvent("EJ_LOOT_DATA_RECIEVED")
 	LootSpecHelperEventFrame:SetScript("OnEvent", LootSpecHelperEventFrame.OnEvent);
 end
+
+function LootSpecHelperEventFrame:OnEvent(event, text, ... )
+	if(event == "PLAYER_ENTERING_WORLD") then
+        C_AddOns.LoadAddOn("Blizzard_EncounterJournal")
+        C_Timer.After(0.2, function()
+            resetLSH()
+        end)
+    elseif(event == "ADDON_LOADED" ) then
+        if(text == "LootSpecHelper") then
+            LootSpecHelperEventFrame:LoadSavedVariables();
+        end
+        if(text == "Blizzard_EncounterJournal") then
+            lsh_journal_opened = true;
+        end
+    elseif(event == "PLAYER_TARGET_CHANGED") then
+        checkTarget()
+    elseif(event == "ENCOUNTER_END") then
+        encounterName, encounterID, difficultyID, groupSize, success = ...;
+        -- for RELEASE comment print
+        --print("the encounter that just ended has the name  of " .. encounterName)
+        if encounterName == mostRecentBoss then
+            mostRecentBoss = nil;
+        end
+    elseif(event == "CHALLENGE_MODE_COMPLETED") then
+        local currentInstanceName = GetInstanceInfo()
+        if runningTargetedKey == true then
+            determineDungeonDropsForLootSpecs(currentInstanceName);
+            runningTargetedKey = false;
+        end
+
+    elseif(event == "EJ_LOOT_DATA_RECIEVED") then
+        checkLoadedItem(text)
+    end 
+end --function
+
+LootSpecHelperEventFrame:RegisterEvent("PLAYER_ENTERING_WORLD");
+LootSpecHelperEventFrame:RegisterEvent("ADDON_LOADED")
+LootSpecHelperEventFrame:RegisterEvent("CHALLENGE_MODE_COMPLETED")
+LootSpecHelperEventFrame:RegisterEvent("UNIT_INVENTORY_CHANGED")
+LootSpecHelperEventFrame:SetScript("OnEvent", LootSpecHelperEventFrame.OnEvent);
 
 function LootSpecHelperEventFrame:LoadSavedVariables()
 	if targetedItemsRaid == nil then
@@ -343,7 +404,9 @@ function checkLoadedItem(loadedItemId)
         local itemLink2 = "|cffa335ee|Hitem:"..itemId..enchantID..gemID1..gemID2..gemID3..gemID4..suffixID..uniqueID..linkLevel..specializationID..modifiersMask..itemContext..numBonusIDs..numModifiers..relic1NumBonusIDs..relic2NumBonusIDs..relic3NumBonusIDs..crafterGUID..extraEnchantID
         itemLink2 = itemLink2.."|h[" .. name .. "]|h|r"
         return itemLink2
-    end
+    end    
+
+    
     local lsh_removeCounter = 1;
     for _,v in pairs(notLoadedItems) do
         if v == loadedItemId then
@@ -366,57 +429,35 @@ function checkLoadedItem(loadedItemId)
     end
 end
 
-function LootSpecHelperEventFrame:OnEvent(event, text, ... )
-	if(event == "PLAYER_ENTERING_WORLD") then
-        disabled = false;
-        mostRecentBoss = nil;
-        firstLoading = true
-        lsh_journal_opened = false;
-        LootSpecHelperEventFrame:onLoad();
-        inInstance, instanceType = IsInInstance()
-        if (inInstance) and (instanceType == "party") then
-            local inTargetedInstance = false;
-            lsh_instanceName, instanceType, difficultyID, difficultyName, maxPlayers, dynamicDifficulty, isDynamic, instanceID, instanceGroupSize, LfgDungeonID = GetInstanceInfo()
-            for _,v in pairs(targetedItemsDungeon) do
-                if v["dungeon"] == lsh_instanceName then
-                    inTargetedInstance = true;
-                    break;
-                end
-            end
-            if inTargetedInstance == true then
-                determineDungeonDropsForLootSpecs(lsh_instanceName);
-            else
+function resetLSH()
+    disabled = false;
+    mostRecentBoss = nil;
+    firstLoading = true
+    lsh_journal_opened = false;
+    LootSpecHelperEventFrame:onLoad();
+    inInstance, instanceType = IsInInstance()
+    if (inInstance) and (instanceType == "party") then
+        local inTargetedInstance = false;
+        lsh_instanceName, instanceType, difficultyID, difficultyName, maxPlayers, dynamicDifficulty, isDynamic, instanceID, instanceGroupSize, LfgDungeonID = GetInstanceInfo()
+        for _,v in pairs(targetedItemsDungeon) do
+            if v["dungeon"] == lsh_instanceName then
+                inTargetedInstance = true;
+                runningTargetedKey = true;
+                break;
             end
         end
-    elseif(event == "ADDON_LOADED" ) then
-        if(text == "LootSpecHelper") then
-            LootSpecHelperEventFrame:LoadSavedVariables();
+        if inTargetedInstance == true then
+            determineDungeonDropsForLootSpecs(lsh_instanceName);
+        else
+            runningTargetedKey = false;
         end
-        if(text == "Blizzard_EncounterJournal") then
-            lsh_journal_opened = true;
-        end
-    elseif(event == "PLAYER_TARGET_CHANGED") then
-        checkTarget()
-    elseif(event == "ENCOUNTER_END") then
-        encounterName, encounterID, difficultyID, groupSize, success = ...;
-        -- for RELEASE comment print
-        --print("the encounter that just ended has the name  of " .. encounterName)
-        if encounterName == mostRecentBoss then
-            mostRecentBoss = nil;
-        end
-    elseif(event == "EJ_LOOT_DATA_RECIEVED") then
-        checkLoadedItem(text)
-    end -- if its the event we want
-end --function
-
-LootSpecHelperEventFrame:RegisterEvent("PLAYER_ENTERING_WORLD");
-LootSpecHelperEventFrame:RegisterEvent("ADDON_LOADED")
-LootSpecHelperEventFrame:SetScript("OnEvent", LootSpecHelperEventFrame.OnEvent);
+    end
+end
 
 function LootSpecHelperEventFrame:CreateLootSpecHelperWindow()
     local raids, dungeons = self:CustomGetInstanceInfo()
 
-    local function setLoot(key, type, dungeonName)
+    local function setLoot(key, type, dungeonName, keyLevel)
         local function buildLink(id, name)
             local specIndex = GetSpecialization();
             local specId = GetSpecializationInfo(specIndex)
@@ -537,6 +578,9 @@ function LootSpecHelperEventFrame:CreateLootSpecHelperWindow()
                 index = index + 1
             end
         elseif type == "dungeon" then
+            local latestTierIndex = EJ_GetNumTiers()
+            EJ_SelectTier(latestTierIndex)
+
             EJ_SelectInstance(encounterIDs[key])
             EJ_SetDifficulty(8)
             for i = 1, EJ_GetNumLoot(), 1 do
@@ -548,16 +592,13 @@ function LootSpecHelperEventFrame:CreateLootSpecHelperWindow()
                 local encounterID = itemId["encounterID"]
                 local icon = itemId["icon"]
                 if name ~= nil then
-                    local itemLink = buildLink(itemID, name)
-                    table.insert(loot, {itemID = itemID,  encounterId = encounterID, name = name, icon = icon, slot = slot, dungeon = dungeonName, link = itemLink});
+                    table.insert(loot, {itemID = itemID,  encounterId = encounterID, name = name, icon = icon, slot = slot, dungeon = dungeonName, level = keyLevel+1});
                     table.insert(lootNames, name);
                 else
-                    local itemLink = "|cffa335ee|Hitem:".. itemID .. "]|h|r"
-                    table.insert(loot, {itemID = itemID,  encounterId = encounterID, name = name, icon = icon, slot = slot, dungeon = dungeonName, link = itemLink});
+                    table.insert(loot, {itemID = itemID,  encounterId = encounterID, name = name, icon = icon, slot = slot, dungeon = dungeonName, level = keyLevel+1});
                     table.insert(lootNames, name);
                     table.insert( notLoadedItems, itemID )
                 end
-                --local itemLink = buildLink(itemID, name)
             end
         end
         if lsh_journal_opened == true then
@@ -565,8 +606,9 @@ function LootSpecHelperEventFrame:CreateLootSpecHelperWindow()
         end
     end
 
-    local function NewItemPopupRaid(lsh_currentPoint, lsh_returnedX, lsh_returnedY)
+    local function NewItemPopupRaid(lsh_currentPoint, lsh_returnedX, lsh_returnedY, parent)
         local function addToTargeted()
+            -- check if the item is already in the targeted list with the passed difficulty
             local function checkContains(checkDifficulty)
                 for _,checkingV in pairs(targetedItemsRaid) do
                     if (selectedItem["itemID"] == checkingV["itemId"]) and (checkDifficulty == checkingV["difficulty"]) then
@@ -577,6 +619,7 @@ function LootSpecHelperEventFrame:CreateLootSpecHelperWindow()
             end
 
             if difficulty == "All" then
+                -- if the lfr item isnt already targeted, add it
                 if checkContains("Lfr") == false then
                     local class_id = select(3,UnitClass('player'))
                     local properLink = selectedItem["link"]
@@ -595,6 +638,7 @@ function LootSpecHelperEventFrame:CreateLootSpecHelperWindow()
                     table.insert(targetedItemsRaid, {itemId = selectedItem["itemID"], name = selectedItem["name"], icon = selectedItem["icon"], difficulty = "Lfr", boss = selectedItem["bossName"], encounterId = selectedItem["encounterId"], link = properLink})
                 end
 
+                -- if the normal item isnt already targeted, add it
                 if checkContains("Normal") == false then
                     local class_id = select(3,UnitClass('player'))
                     local properLink = selectedItem["link"]
@@ -613,6 +657,7 @@ function LootSpecHelperEventFrame:CreateLootSpecHelperWindow()
                     table.insert(targetedItemsRaid, {itemId = selectedItem["itemID"], name = selectedItem["name"], icon = selectedItem["icon"], difficulty = "Normal", boss = selectedItem["bossName"], encounterId = selectedItem["encounterId"], link = properLink})
                 end
 
+                -- if the heroic item isnt already targeted, add it
                 if checkContains("Heroic") == false then
                     local class_id = select(3,UnitClass('player'))
                     local properLink = selectedItem["link"]
@@ -631,6 +676,7 @@ function LootSpecHelperEventFrame:CreateLootSpecHelperWindow()
                     table.insert(targetedItemsRaid, {itemId = selectedItem["itemID"], name = selectedItem["name"], icon = selectedItem["icon"], difficulty = "Heroic", boss = selectedItem["bossName"], encounterId = selectedItem["encounterId"], link = properLink})
                 end
 
+                -- if the mythic item isnt already targeted, add it
                 if checkContains("Mythic") == false then
                     local class_id = select(3,UnitClass('player'))
                     local properLink = selectedItem["link"]
@@ -652,8 +698,36 @@ function LootSpecHelperEventFrame:CreateLootSpecHelperWindow()
                 return
             end
 
-            if checkContains(difficulty) == false then
-                table.insert(targetedItemsRaid, {itemId = selectedItem["itemID"], name = selectedItem["name"], icon = selectedItem["icon"], difficulty = difficulty, boss = selectedItem["bossName"], encounterId = selectedItem["encounterId"], link = selectedItem["link"]})
+            local difficultyMap = {
+                ["Lfr"] = {"Normal", "Heroic", "Mythic"},
+                ["Normal"] = {"Heroic", "Mythic"},
+                ["Heroic"] = {"Mythic"},
+                ["Mythic"] = {}
+            }
+
+            local difficulties = difficultyMap[difficulty]
+            table.insert(difficulties, 1, difficulty) -- Add the selected difficulty to the front of the list
+
+            -- add all the difficulties including and above the selected one
+            for _, diff in ipairs(difficulties) do
+                if checkContains(diff) == false then
+                    local class_id = select(3,UnitClass('player'))
+                    local properLink = selectedItem["link"]
+                    EJ_SetLootFilter(class_id)
+                    EJ_SelectEncounter(selectedItem["encounterId"])
+                    local difficultyId = diff == "Lfr" and 17 or (diff == "Normal" and 14 or (diff == "Heroic" and 15 or 16))
+                    EJ_SetDifficulty(difficultyId)
+                    index = 1
+                    while true do
+                        local lootItem = C_EncounterJournal.GetLootInfoByIndex(index);
+                        if lootItem["itemID"] == selectedItem["itemID"] then
+                            properLink = lootItem["link"]
+                            break
+                        end
+                        index = index + 1
+                    end
+                    table.insert(targetedItemsRaid, {itemId = selectedItem["itemID"], name = selectedItem["name"], icon = selectedItem["icon"], difficulty = diff, boss = selectedItem["bossName"], encounterId = selectedItem["encounterId"], link = properLink})
+                end
             end
         end
 
@@ -716,7 +790,7 @@ function LootSpecHelperEventFrame:CreateLootSpecHelperWindow()
                 local lsh_currentPoint, lsh_returnedTableThing, lsh_currentPointRepeat, lsh_returnedX, lsh_returnedY = addFrameGlobal:GetPoint()
                 addFrameGlobal:ReleaseChildren();
                 addFrameGlobal:Release();
-                NewItemPopupRaid(lsh_currentPoint, lsh_returnedX, lsh_returnedY)
+                NewItemPopupRaid(lsh_currentPoint, lsh_returnedX, lsh_returnedY, parent)
             end)
         end)
 
@@ -746,6 +820,9 @@ function LootSpecHelperEventFrame:CreateLootSpecHelperWindow()
                 loot = {};
                 lootNames = {};
                 globalTab:SelectTab("tab1")
+                if parent ~= nil then
+                    parent:DoLayout()
+                end
             else
                 --TODO: space this out more vertically, and center it horizontally
                 local errorFrame = AceGUI:Create("Window")
@@ -766,7 +843,7 @@ function LootSpecHelperEventFrame:CreateLootSpecHelperWindow()
                     local lsh_currentPoint, lsh_returnedTableThing, lsh_currentPointRepeat, lsh_returnedX, lsh_returnedY = addFrameGlobal:GetPoint()
                     addFrameGlobal:ReleaseChildren();
                     addFrameGlobal:Release();
-                    NewItemPopupRaid(lsh_currentPoint, lsh_returnedX, lsh_returnedY)
+                    NewItemPopupRaid(lsh_currentPoint, lsh_returnedX, lsh_returnedY, parent)
                 end);
                 errorFrame:AddChild(okButton);
                 addFrameGlobal:AddChild(errorFrame)
@@ -788,15 +865,16 @@ function LootSpecHelperEventFrame:CreateLootSpecHelperWindow()
         end)
     end -- new item popup raid
 
-    local function NewItemPopupDungeon(lsh_currentPoint, lsh_returnedX, lsh_returnedY)
+    local function NewItemPopupDungeon(lsh_currentPoint, lsh_returnedX, lsh_returnedY, parent)
         local function addToTargeted()
+            -- loop through and make sure it isnt already there
             for k,v in pairs(targetedItemsDungeon) do
                 if (selectedItem["itemID"] == v["itemId"]) then
                     return
                 end
             end
 
-            table.insert(targetedItemsDungeon, {itemId = selectedItem["itemID"], name = selectedItem["name"], icon = selectedItem["icon"], dungeon = selectedItem["dungeon"], link = selectedItem["link"]})
+            table.insert(targetedItemsDungeon, {itemId = selectedItem["itemID"], name = selectedItem["name"], icon = selectedItem["icon"], dungeon = selectedItem["dungeon"], level = selectedItem["level"]})
         end
 
         encounterIDs = {};
@@ -828,12 +906,12 @@ function LootSpecHelperEventFrame:CreateLootSpecHelperWindow()
             dungeonLevel = keyLevels[key];
             dungeonLevelIndex = key;
             if dungeonIndex ~= nil then
-                setLoot(dungeonIndex, "dungeon", dungeon);
+                setLoot(dungeonIndex, "dungeon", dungeon, dungeonLevelIndex);
                 C_Timer.After(0.4, function()
                     local lsh_currentPoint, lsh_returnedTableThing, lsh_currentPointRepeat, lsh_returnedX, lsh_returnedY = addFrameGlobal:GetPoint()
                     addFrameGlobal:ReleaseChildren();
                     addFrameGlobal:Release();
-                    NewItemPopupDungeon(lsh_currentPoint, lsh_returnedX, lsh_returnedY);
+                    NewItemPopupDungeon(lsh_currentPoint, lsh_returnedX, lsh_returnedY, parent);
                 end)
             end
         end)
@@ -848,18 +926,18 @@ function LootSpecHelperEventFrame:CreateLootSpecHelperWindow()
         dungeonDropdown:SetCallback("OnValueChanged", function(widget, event, key)
             dungeon = dungeonsOnly[key];
             dungeonIndex = key;
-            setLoot(key, "dungeon", dungeon);
+            setLoot(key, "dungeon", dungeon, dungeonLevelIndex);
             if encounterLoadedStatus[dungeon] == false then
                 encounterLoadedStatus[dungeon] = true
                 C_Timer.After(0.1, function()
-                    setLoot(key, "dungeon", dungeon);
+                    setLoot(key, "dungeon", dungeon, dungeonLevelIndex);
                 end)
             end
             C_Timer.After(0.2, function()
                 local lsh_currentPoint, lsh_returnedTableThing, lsh_currentPointRepeat, lsh_returnedX, lsh_returnedY = addFrameGlobal:GetPoint()
                 addFrameGlobal:ReleaseChildren();
                 addFrameGlobal:Release();
-                NewItemPopupDungeon(lsh_currentPoint, lsh_returnedX, lsh_returnedY);
+                NewItemPopupDungeon(lsh_currentPoint, lsh_returnedX, lsh_returnedY, parent);
             end)
         end)
         addFrameGlobal:AddChild(dungeonDropdown);
@@ -886,6 +964,9 @@ function LootSpecHelperEventFrame:CreateLootSpecHelperWindow()
                 selectedItem = nil;
                 dungeonSaved = true;
                 globalTab:SelectTab("tab2")
+                if parent ~= nil then
+                    parent:DoLayout()
+                end
             else
                 --TODO: space this out more vertically, and center it horizontally
                 local errorFrame = AceGUI:Create("Window")
@@ -904,7 +985,7 @@ function LootSpecHelperEventFrame:CreateLootSpecHelperWindow()
                     local lsh_currentPoint, lsh_returnedTableThing, lsh_currentPointRepeat, lsh_returnedX, lsh_returnedY = addFrameGlobal:GetPoint()
                     addFrameGlobal:ReleaseChildren();
                     addFrameGlobal:Release();
-                    NewItemPopupDungeon(lsh_currentPoint, lsh_returnedX, lsh_returnedY)
+                    NewItemPopupDungeon(lsh_currentPoint, lsh_returnedX, lsh_returnedY, parent)
                 end);
                 errorFrame:AddChild(okButton);
                 addFrameGlobal:AddChild(errorFrame)
@@ -945,52 +1026,190 @@ function LootSpecHelperEventFrame:CreateLootSpecHelperWindow()
         raidScroll:SetLayout("Flow");
         raidTabContainer:AddChild(raidScroll);
 
+        -- Create a full-width container
+        local container = AceGUI:Create("SimpleGroup")
+        container:SetFullWidth(true)
+        container:SetLayout("Flow")
+        raidScroll:AddChild(container)
+
+        -- Create a spacer
+        local spacer1 = AceGUI:Create("Label")
+        spacer1:SetText(" ")
+        spacer1:SetWidth(10) --hardcoded to properly center when the window first opens
+        container:AddChild(spacer1)
+
+        -- Create the button
+        local button = AceGUI:Create("Button")
+        button:SetText("Add item")
+        button:SetWidth(325)
+        button:SetCallback("OnClick", function() NewItemPopupRaid(nil, nil, nil, raidScroll) end)
+        container:AddChild(button)
+
+        -- Create another spacer
+        local spacer2 = AceGUI:Create("Label")
+        spacer2:SetText(" ")
+        container:AddChild(spacer2)
+
+        -- Set up an OnUpdate script on the container's frame
+        container.frame:SetScript("OnUpdate", function()
+            -- Calculate the width of the spacers
+            local spacerWidth = (container.frame:GetWidth() - button.frame:GetWidth() - 20) / 2  -- Subtract a fixed value
+
+            -- Set the width of the spacers
+            spacer1:SetWidth(spacerWidth)
+            spacer2:SetWidth(spacerWidth)
+        end)
+
         targetedItemContainer = AceGUI:Create("SimpleGroup");
         targetedItemContainer:SetLayout("List");
         targetedItemContainer:SetFullWidth(true);
         raidScroll:AddChild(targetedItemContainer);
 
+        -- Create a table to group items by boss and name
+        local groupedItems = {}
         for k,v in pairs(targetedItemsRaid) do
-            --TODO: center the icon horizontally or at least align with the text and push delete button to the right side
-
-            cardContainer = AceGUI:Create("SimpleGroup");
-            cardContainer:SetLayout("Flow");
-            cardContainer:SetFullWidth(true);
-            targetedItemContainer:AddChild(cardContainer);
-
-            --TODO: need to center this horizontally
-
-            local targetItem = AceGUI:Create("InteractiveLabel");
-            targetItem:SetText(v["name"] .. " - " .. v["difficulty"]);
-            targetItem:SetImage(GetItemIcon(v["itemId"]));
-            targetItem:SetImageSize(50,50);
-            targetItem:SetCallback("OnEnter", function(widget)
-                GameTooltip:SetOwner(LootSpecHelperEventFrame, "ANCHOR_CURSOR")
-                if ( (IsModifiedClick("COMPAREITEMS") or GetCVarBool("alwaysCompareItems")) ) then
-                    GameTooltip_ShowCompareItem(GameTooltip)
-                end
-                GameTooltip:SetHyperlink(v["link"])
-            end)
-            targetItem:SetCallback("OnLeave", function(widget) GameTooltip:FadeOut() end)
-            cardContainer:AddChild(targetItem);
-
-            local deleteButton = AceGUI:Create("Button")
-            deleteButton:SetHeight(20)
-            deleteButton:SetWidth(100)
-            deleteButton:SetText("DELETE")
-            deleteButton:SetCallback("OnClick", function()
-                removeTargetedItem(v["itemId"],v["difficulty"])
-                globalTab:SelectTab("tab1")
-            end)
-            cardContainer:AddChild(deleteButton);
+            if not groupedItems[v["boss"]] then
+                groupedItems[v["boss"]] = {}
+            end
+            if not groupedItems[v["boss"]][v["name"]] then
+                groupedItems[v["boss"]][v["name"]] = {v}
+            else
+                table.insert(groupedItems[v["boss"]][v["name"]], v)
+            end
         end
 
-        --TODO: anchor the button to the bottom of the container and center horizontally.
-        local button = AceGUI:Create("Button");
-        button:SetText("Add item");
-        button:SetCallback("OnClick", function() NewItemPopupRaid(nil) end)
-        button:SetWidth(325);
-        raidScroll:AddChild(button);
+        -- Now create containers for each boss
+        for boss, items in pairs(groupedItems) do
+            -- Create a container for the boss
+            local bossContainer = AceGUI:Create("InlineGroup")
+            bossContainer:SetLayout("Flow")
+            bossContainer:SetFullWidth(true)
+            targetedItemContainer:AddChild(bossContainer)
+
+            -- Create a label for the boss and add it to the container
+            local bossLabel = AceGUI:Create("InteractiveLabel")
+            bossLabel:SetText(boss)
+            bossLabel:SetColor(1, 0, 0) -- Set the color to red. Values are RGB.
+            bossLabel:SetFontObject(GameFontNormalLarge)
+            bossLabel:SetFullWidth(true)
+            bossContainer:AddChild(bossLabel)
+
+            -- Add items to the boss container
+            for itemName, itemGroup in pairs(items) do
+                -- Create a card container for the item
+                local cardContainer = AceGUI:Create("InlineGroup")
+                cardContainer:SetLayout("Flow")
+                cardContainer:SetWidth(150)
+                bossContainer:AddChild(cardContainer)
+
+                -- Create a label for the item
+                local targetItem = AceGUI:Create("InteractiveLabel")
+                local difficulties = {}
+                for _, item in ipairs(itemGroup) do
+                    table.insert(difficulties, item["difficulty"])
+                end
+                local difficultiesStr = table.concat(difficulties, "\n")
+
+                -- Count the number of lines in difficultiesStr
+                local _, numLines = difficultiesStr:gsub("\n", "\n")
+                -- If there are less than 5 lines, add the necessary number of newline characters
+                if numLines < 5 then
+                    difficultiesStr = difficultiesStr .. string.rep("\n", 5 - numLines)
+                end
+
+                -- Create a hidden font string
+                local fontString = targetItem.frame:CreateFontString(nil, "BACKGROUND", "GameFontNormal")
+
+                function truncateString(str, maxWidth)
+                    -- Set the text of the font string to your string
+                    fontString:SetText(str)
+
+                    while fontString:GetStringWidth() > maxWidth do
+                        -- Remove the last character from str
+                        str = str:sub(1, -2)
+
+                        -- Update the text of the font string
+                        fontString:SetText(str)
+                    end
+
+                    -- Add "..." at the end of str
+                    str = str .. "..."
+
+                    return str
+                end
+
+                local truncatedItemName = truncateString(itemName, 150)
+                targetItem:SetText(truncatedItemName .. "\n" .. difficultiesStr)
+                targetItem:SetImage(GetItemIcon(itemGroup[1]["itemId"]))
+                targetItem:SetImageSize(50,50)
+                targetItem:SetCallback("OnEnter", function(widget)
+                    GameTooltip:SetOwner(LootSpecHelperEventFrame, "ANCHOR_CURSOR")
+                    if ( (IsModifiedClick("COMPAREITEMS") or GetCVarBool("alwaysCompareItems")) ) then
+                        GameTooltip_ShowCompareItem(GameTooltip)
+                    end
+                    GameTooltip:SetHyperlink(itemGroup[1]["link"])
+                end)
+                targetItem:SetCallback("OnLeave", function(widget) GameTooltip:FadeOut() end)
+                cardContainer:AddChild(targetItem)
+
+                local difficultyMap = {
+                    ["All"] = {"Mythic", "Heroic", "Normal", "Lfr"},
+                    ["Mythic"] = {"Heroic", "Normal", "Lfr"},
+                    ["Heroic"] = {"Normal", "Lfr"},
+                    ["Normal"] = {"Lfr"},
+                    ["Lfr"] = {}
+                }
+
+                -- Create a delete button for the item
+                local deleteButton = AceGUI:Create("Button")
+                deleteButton:SetHeight(20)
+                deleteButton:SetWidth(100)
+                deleteButton:SetText("DELETE")
+                deleteButton:SetCallback("OnClick", function()
+                    -- Create a new frame for the popup
+                    local popupFrame = AceGUI:Create("Frame")
+                    popupFrame:SetTitle("Delete Items")
+                    popupFrame:SetLayout("Flow")
+                    popupFrame:SetWidth(300)
+                    popupFrame:SetHeight(200)
+
+                    -- Create a label for the dropdown
+                    local label = AceGUI:Create("Label")
+                    label:SetText("Select the highest difficulty to delete. All lower difficulties will also be deleted.")
+                    popupFrame:AddChild(label)
+
+                    -- Create the dropdown
+                    local difficultyDropdown = AceGUI:Create("Dropdown")
+                    difficultyDropdown:SetList(raidDifficulties)
+                    difficultyDropdown:SetText("Difficulty")
+                    difficultyDropdown:SetCallback("OnValueChanged", function(widget, event, key)
+                        -- Get the selected difficulty
+                        local selectedDifficulty = raidDifficulties[key]
+                    
+                        -- Delete the items of the selected difficulty and all lower difficulties
+                        for _, item in ipairs(itemGroup) do
+                            if item["difficulty"] == selectedDifficulty or (difficultyMap[selectedDifficulty] and tContains(difficultyMap[selectedDifficulty], item["difficulty"])) then
+                                removeTargetedItem(item["itemId"], item["difficulty"])
+                            end
+                        end
+                        popupFrame:Hide()
+                        globalTab:SelectTab("tab1")
+
+                        -- Manually trigger the OnUpdate script
+                        container.frame:GetScript("OnUpdate")()
+                        raidScroll:DoLayout()
+                    end)
+                    if difficultyIndex ~= nil then
+                        difficultyDropdown:SetValue(difficultyIndex)
+                    end
+                    popupFrame:AddChild(difficultyDropdown)
+                end)
+                cardContainer:AddChild(deleteButton)
+            end
+        end
+        C_Timer.After(0.1, function()
+            raidScroll:DoLayout()
+        end)
     end -- draw raid
 
 	local function DrawDungeon(container)
@@ -1002,6 +1221,68 @@ function LootSpecHelperEventFrame:CreateLootSpecHelperWindow()
             end
         end
 
+    --UPDATE step 3: update these ilvls/ranks for the new dungeon levels.
+    local keyLevelInformation = {
+        [2] = {ilvl = 441, upgradeLevel = 1, upgradeMax = 8},
+        [3] = {ilvl = 444, upgradeLevel = 2, upgradeMax = 8},
+        [4] = {ilvl = 444, upgradeLevel = 2, upgradeMax = 8},
+        [5] = {ilvl = 447, upgradeLevel = 3, upgradeMax = 8},
+        [6] = {ilvl = 447, upgradeLevel = 3, upgradeMax = 8},
+        [7] = {ilvl = 450, upgradeLevel = 4, upgradeMax = 8},
+        [8] = {ilvl = 450, upgradeLevel = 4, upgradeMax = 8},
+        [9] = {ilvl = 454, upgradeLevel = 1, upgradeMax = 8},
+        [10] = {ilvl = 454, upgradeLevel = 1, upgradeMax = 8},
+        [11] = {ilvl = 457, upgradeLevel = 2, upgradeMax = 8},
+        [12] = {ilvl = 457, upgradeLevel = 2, upgradeMax = 8},
+        [13] = {ilvl = 460, upgradeLevel = 3, upgradeMax = 8},
+        [14] = {ilvl = 460, upgradeLevel = 3, upgradeMax = 8},
+        [15] = {ilvl = 463, upgradeLevel = 4, upgradeMax = 8},
+        [16] = {ilvl = 463, upgradeLevel = 4, upgradeMax = 8},
+        [17] = {ilvl = 467, upgradeLevel = 1, upgradeMax = 6},
+        [18] = {ilvl = 467, upgradeLevel = 1, upgradeMax = 6},
+        [19] = {ilvl = 470, upgradeLevel = 2, upgradeMax = 6},
+        [20] = {ilvl = 470, upgradeLevel = 2, upgradeMax = 6},
+        [21] = {ilvl = 483, upgradeLevel = 6, upgradeMax = 6}, -- max rank from +20 loot
+        [22] = {ilvl = 489, upgradeLevel = 4, upgradeMax = 4} -- max rank for max vault loot
+    }
+
+    local function GenerateTooltip(itemID, keyLevel)
+        local upgradeLevel = keyLevelInformation[keyLevel]["upgradeLevel"];
+        local upgradeMax = keyLevelInformation[keyLevel]["upgradeMax"];
+        local itemLevel = keyLevelInformation[keyLevel]["ilvl"];
+        local tooltipData = C_TooltipInfo.GetItemKey(itemID, itemLevel, 0)
+
+        if keyLevel == 21 then
+            keyLevel = 20
+        elseif keyLevel == 22 then
+            keyLevel = "Vault"
+        end
+    
+        tooltipData.lines[1].leftColor = ITEM_QUALITY_COLORS[Enum.ItemQuality.Epic].color
+        table.insert(tooltipData.lines, 2, {
+          type = 0,
+          leftText = PLAYER_DIFFICULTY_MYTHIC_PLUS .. " " .. keyLevel,
+          leftColor = GREEN_FONT_COLOR,
+        })
+        table.insert(tooltipData.lines, 4, {
+          type = 0,
+          leftText = ITEM_UPGRADE_TOOLTIP_FORMAT:format(upgradeLevel, upgradeMax),
+          leftColor = NORMAL_FONT_COLOR,
+        })
+        for index, line in ipairs(tooltipData.lines) do
+          if line.leftText == AUCTION_HOUSE_BUCKET_VARIATION_EQUIPMENT_TOOLTIP then
+            table.remove(tooltipData.lines, index)
+            table.remove(tooltipData.lines, index - 1)
+            break
+          end
+        end
+        local info = {
+          tooltipData = tooltipData,
+        }
+        GameTooltip:ProcessInfo(info)
+        GameTooltip:Show()
+    end
+
         dungeonTabContainer = AceGUI:Create("SimpleGroup");
         dungeonTabContainer:SetFullWidth(true);
         dungeonTabContainer:SetFullHeight(true);
@@ -1012,52 +1293,146 @@ function LootSpecHelperEventFrame:CreateLootSpecHelperWindow()
         dungeonScroll:SetLayout("Flow");
         dungeonTabContainer:AddChild(dungeonScroll);
 
+        -- Create a full-width container
+        local container = AceGUI:Create("SimpleGroup")
+        container:SetFullWidth(true)
+        container:SetLayout("Flow")
+        dungeonScroll:AddChild(container)
+
+        -- Create a spacer
+        local spacer1 = AceGUI:Create("Label")
+        spacer1:SetText(" ")
+        spacer1:SetWidth(10) --hardcoded to properly center when the window first opens
+        container:AddChild(spacer1)
+
+        -- Create the button
+        local button = AceGUI:Create("Button")
+        button:SetText("Add item")
+        button:SetWidth(325)
+        button:SetCallback("OnClick", function() NewItemPopupDungeon(nil, nil, nil, dungeonScroll) end)
+        container:AddChild(button)
+
+        -- Create another spacer
+        local spacer2 = AceGUI:Create("Label")
+        spacer2:SetText(" ")
+        container:AddChild(spacer2)
+
+        -- Set up an OnUpdate script on the container's frame
+        container.frame:SetScript("OnUpdate", function()
+            -- Calculate the width of the spacers
+            local spacerWidth = (container.frame:GetWidth() - button.frame:GetWidth()) / 2
+
+            -- Set the width of the spacers
+            spacer1:SetWidth(spacerWidth)
+            spacer2:SetWidth(spacerWidth)
+        end)
+        
         targetedItemContainer = AceGUI:Create("SimpleGroup");
         targetedItemContainer:SetLayout("List");
         targetedItemContainer:SetFullWidth(true);
         dungeonScroll:AddChild(targetedItemContainer);
 
+        -- Create a table to group items by dungeon and name
+        local groupedItems = {}
         for k,v in pairs(targetedItemsDungeon) do
-            --TODO: center the icon horizontally or at least align with the text and push delete button to the right side
-
-            cardContainer = AceGUI:Create("SimpleGroup");
-            cardContainer:SetLayout("Flow");
-            cardContainer:SetFullWidth(true);
-            targetedItemContainer:AddChild(cardContainer);
-
-            --TODO: need to center this horizontally
-
-            local targetItem = AceGUI:Create("InteractiveLabel");
-            targetItem:SetText(v["name"] .. " - " .. v["dungeon"]);
-            targetItem:SetImage(GetItemIcon(v["itemId"]));
-            targetItem:SetImageSize(50,50);
-            targetItem:SetCallback("OnEnter", function(widget) 
-                GameTooltip:SetOwner(LootSpecHelperEventFrame, "ANCHOR_CURSOR")
-                if ( (IsModifiedClick("COMPAREITEMS") or GetCVarBool("alwaysCompareItems")) ) then
-                    GameTooltip_ShowCompareItem(GameTooltip)
-                end
-                GameTooltip:SetHyperlink(v["link"])
-            end)
-            targetItem:SetCallback("OnLeave", function(widget) GameTooltip:FadeOut() end)
-            cardContainer:AddChild(targetItem);
-
-            local deleteButton = AceGUI:Create("Button")
-            deleteButton:SetHeight(20)
-            deleteButton:SetWidth(100)
-            deleteButton:SetText("DELETE")
-            deleteButton:SetCallback("OnClick", function()
-                removeTargetedItem(v["itemId"])
-                globalTab:SelectTab("tab2")
-            end)
-            cardContainer:AddChild(deleteButton);
+            if not groupedItems[v["dungeon"]] then
+                groupedItems[v["dungeon"]] = {}
+            end
+            if not groupedItems[v["dungeon"]][v["name"]] then
+                groupedItems[v["dungeon"]][v["name"]] = {v}
+            else
+                table.insert(groupedItems[v["dungeon"]][v["name"]], v)
+            end
         end
 
-        --TODO: anchor the button to the bottom of the container and center horizontally.
-        local button = AceGUI:Create("Button");
-        button:SetText("Add item");
-        button:SetCallback("OnClick", function() NewItemPopupDungeon(nil) end)
-        button:SetWidth(325);
-        dungeonScroll:AddChild(button);
+        -- Now create containers for each dungeon
+        for dungeon, items in pairs(groupedItems) do
+            -- Create a container for the dungeon
+            local dungeonContainer = AceGUI:Create("InlineGroup")
+            dungeonContainer:SetLayout("Flow")
+            dungeonContainer:SetFullWidth(true)
+            targetedItemContainer:AddChild(dungeonContainer)
+
+            -- Create a label for the dungeon and add it to the container
+            local dungeonLabel = AceGUI:Create("InteractiveLabel")
+            dungeonLabel:SetText(dungeon)
+            dungeonLabel:SetColor(1, 0, 0) -- Set the color to red. Values are RGB.
+            dungeonLabel:SetFontObject(GameFontNormalLarge)
+            dungeonLabel:SetFullWidth(true)
+            dungeonContainer:AddChild(dungeonLabel)
+
+            -- Add items to the dungeon container
+            for itemName, itemGroup in pairs(items) do
+                -- Create a card container for the item
+                local cardContainer = AceGUI:Create("InlineGroup")
+                cardContainer:SetLayout("Flow")
+                cardContainer:SetWidth(150)
+                dungeonContainer:AddChild(cardContainer)
+
+                -- Create a label for the item
+                local targetItem = AceGUI:Create("InteractiveLabel")
+
+                -- Create a hidden font string
+                local fontString = targetItem.frame:CreateFontString(nil, "BACKGROUND", "GameFontNormal")
+
+                function truncateString(str, maxWidth)
+                    -- Set the text of the font string to your string
+                    fontString:SetText(str)
+                
+                    -- Check if the string is longer than maxWidth
+                    if fontString:GetStringWidth() > maxWidth then
+                        while fontString:GetStringWidth() > maxWidth do
+                            -- Remove the last character from str
+                            str = str:sub(1, -2)
+                
+                            -- Update the text of the font string
+                            fontString:SetText(str)
+                        end
+                
+                        -- Add "..." at the end of str
+                        str = str .. "..."
+                    end
+                
+                    return str
+                end
+
+                local truncatedItemName = truncateString(itemName, 150)
+                targetItem:SetText(truncatedItemName)
+                targetItem:SetImage(GetItemIcon(itemGroup[1]["itemId"]))
+                targetItem:SetImageSize(50,50)
+                targetItem:SetCallback("OnEnter", function(widget)
+                    GameTooltip:SetOwner(LootSpecHelperEventFrame, "ANCHOR_CURSOR")
+                    if ( (IsModifiedClick("COMPAREITEMS") or GetCVarBool("alwaysCompareItems")) ) then
+                        GameTooltip_ShowCompareItem(GameTooltip)
+                    end
+                    local item = Item:CreateFromItemID(itemGroup[1]["itemId"])
+                    item:ContinueOnItemLoad(function()
+                        GenerateTooltip(itemGroup[1]["itemId"], itemGroup[1]["level"])
+                    end)
+                end)
+                targetItem:SetCallback("OnLeave", function(widget) GameTooltip:FadeOut() end)
+                cardContainer:AddChild(targetItem)
+
+                -- Create a delete button for the item
+                local deleteButton = AceGUI:Create("Button")
+                deleteButton:SetHeight(20)
+                deleteButton:SetWidth(100)
+                deleteButton:SetText("DELETE")
+                deleteButton:SetCallback("OnClick", function()
+                    -- Delete the item
+                    removeTargetedItem(itemGroup[1]["itemId"])
+
+                    globalTab:SelectTab("tab2")
+                    -- Manually trigger the OnUpdate script
+                    container.frame:GetScript("OnUpdate")()
+                    dungeonScroll:DoLayout()
+                end)
+                cardContainer:AddChild(deleteButton)
+            end
+        end
+        C_Timer.After(0.1, function()
+            dungeonScroll:DoLayout()
+        end)
     end -- draw dungeon
 
     -- Callback function for OnGroupSelected
@@ -1070,9 +1445,8 @@ function LootSpecHelperEventFrame:CreateLootSpecHelperWindow()
         end
      end
 
-
     -- Create the frame container
-	local frame = AceGUI:Create("Frame", "LootSpecHelper Main Frame")
+    local frame = AceGUI:Create("Frame", "LootSpecHelper Main Frame")
 
     -- Add the frame as a global variable under the name `MyGlobalFrameName`
     _G["LootSpecHelperGlobalFrameName"] = frame.frame
@@ -1081,10 +1455,11 @@ function LootSpecHelperEventFrame:CreateLootSpecHelperWindow()
     tinsert(UISpecialFrames, "LootSpecHelperGlobalFrameName")
 
     frame:SetWidth(425)
-	frame:SetTitle("LootSpecHelper")
-	frame:SetStatusText("Created by Van on Stormrage.")
-	frame:SetCallback("OnClose", function(widget)
-		AceGUI:Release(widget)
+    frame:SetHeight(500)
+    frame:SetTitle("LootSpecHelper")
+    frame:SetStatusText("Created by Van on Stormrage.")
+    frame:SetCallback("OnClose", function(widget)
+        AceGUI:Release(widget)
         if addFrameGlobal ~= nil then
             addFrameGlobal:ReleaseChildren()
             addFrameGlobal:Release()
@@ -1101,24 +1476,78 @@ function LootSpecHelperEventFrame:CreateLootSpecHelperWindow()
         dungeonIndex = nil;
         dungeonLevel = nil;
         dungeonLevelIndex = nil;
-	end)
-	-- Fill Layout - the TabGroup widget will fill the whole frame
-	frame:SetLayout("Fill")
+    end)
 
-	-- Create the TabGroup
-	globalTab =  AceGUI:Create("TabGroup");
-	globalTab:SetTitle("Instance Type");
-	globalTab:SetLayout("Flow");
+    -- Fill Layout - the TabGroup widget will fill the whole frame
+    frame:SetLayout("Flow")
 
+    -- create and add the button with the text "Reset Popups", add the tooltip "Resets and reactivates LootSpecHelper pop-ups.\nUse /lsh reset in chat for the same action.", then add it to frame
+    local resetButton = AceGUI:Create("Button")
+    resetButton:SetText("Reset Popups")
+    resetButton:SetFullWidth(true)
+    resetButton:SetCallback("OnClick", function(widget)
+        print("LootSpecHelper popups reset.")
+        frame:Fire("OnClose")
+        resetLSH()
+    end)
+    resetButton:SetUserData("tooltip", "Resets and reactivates LootSpecHelper pop-ups.\nUse /lsh reset in chat for the same action.")
+    resetButton:SetCallback("OnEnter", function(widget)
+        local tooltip = widget:GetUserData("tooltip")
+        GameTooltip:SetOwner(widget.frame, "ANCHOR_CURSOR")
+        GameTooltip:SetText(tooltip)
+        GameTooltip:Show()
+    end)
+    resetButton:SetCallback("OnLeave", function(widget)
+        GameTooltip:Hide()
+    end)
+    frame:AddChild(resetButton)
+
+    -- Create and add the disabled checkbox 
+    local checkbox = AceGUI:Create("CheckBox")
+    checkbox:SetLabel("Disable LootSpecHelper")
+    checkbox:SetHeight(25)
+    checkbox:SetFullWidth(true)
+    checkbox:SetValue(disabled)
+    -- Set a callback for the checkbox
+    checkbox:SetCallback("OnValueChanged", function(widget, event)
+        -- Update your variable with the current value of the checkbox
+        disabled = widget:GetValue()
+    end)
+    -- Set the tooltip text
+    checkbox:SetUserData("tooltip", "Disables LootSpecHelper loot reminder popups.\nUse /lsh enable or /lsh disable in chat to toggle.")
+
+    -- Set a callback for when the mouse enters the checkbox
+    checkbox:SetCallback("OnEnter", function(widget)
+        -- Get the tooltip text
+        local tooltip = widget:GetUserData("tooltip")
+        -- Show the tooltip
+        GameTooltip:SetOwner(widget.frame, "ANCHOR_CURSOR")
+        GameTooltip:SetText(tooltip)
+        GameTooltip:Show()
+    end)
+
+    -- Set a callback for when the mouse leaves the checkbox
+    checkbox:SetCallback("OnLeave", function(widget)
+        -- Hide the tooltip
+        GameTooltip:Hide()
+    end)
+
+    frame:AddChild(checkbox) -- Add checkbox to its container
+
+    -- Create the TabGroup
+    globalTab =  AceGUI:Create("TabGroup");
+    globalTab:SetTitle("Instance Type");
+    globalTab:SetFullHeight(true)
+    globalTab:SetFullWidth(true)
+    globalTab:SetLayout("Flow");
     globalTab:SetTabs( { {text="Raid", value="tab1"}, {text="M+", value="tab2"} } )
+    -- Register callback
+    globalTab:SetCallback("OnGroupSelected", SelectGroup)
+    -- Set initial Tab (this will fire the OnGroupSelected callback)
+    globalTab:SelectTab("tab1")
 
-	-- Register callback
-	globalTab:SetCallback("OnGroupSelected", SelectGroup)
-	-- Set initial Tab (this will fire the OnGroupSelected callback)
-	globalTab:SelectTab("tab1")
-
-	-- add to the frame container
-	frame:AddChild(globalTab)
+    -- add the tab container to the frame
+    frame:AddChild(globalTab)
 end--CreateLootSpecHelperWindow
 
 function displaySpecLoot(specTables, sharedTable, passedInstanceType)
@@ -1164,53 +1593,72 @@ function displaySpecLoot(specTables, sharedTable, passedInstanceType)
         end)
         disableButton:SetWidth(200);
         scrollContainer:AddChild(disableButton);
-    end
-    local function buildLink(id, name, lshPassedDifficulty)
-        local levelsBonusId = nil;
+    end  
+    
+    --UPDATE step 4: update these ilvls/ranks for the new dungeon levels (same as step 3's)
+    local keyLevelInformation = {
+        [2] = {ilvl = 441, upgradeLevel = 1, upgradeMax = 8},
+        [3] = {ilvl = 444, upgradeLevel = 2, upgradeMax = 8},
+        [4] = {ilvl = 444, upgradeLevel = 2, upgradeMax = 8},
+        [5] = {ilvl = 447, upgradeLevel = 3, upgradeMax = 8},
+        [6] = {ilvl = 447, upgradeLevel = 3, upgradeMax = 8},
+        [7] = {ilvl = 450, upgradeLevel = 4, upgradeMax = 8},
+        [8] = {ilvl = 450, upgradeLevel = 4, upgradeMax = 8},
+        [9] = {ilvl = 454, upgradeLevel = 1, upgradeMax = 8},
+        [10] = {ilvl = 454, upgradeLevel = 1, upgradeMax = 8},
+        [11] = {ilvl = 457, upgradeLevel = 2, upgradeMax = 8},
+        [12] = {ilvl = 457, upgradeLevel = 2, upgradeMax = 8},
+        [13] = {ilvl = 460, upgradeLevel = 3, upgradeMax = 8},
+        [14] = {ilvl = 460, upgradeLevel = 3, upgradeMax = 8},
+        [15] = {ilvl = 463, upgradeLevel = 4, upgradeMax = 8},
+        [16] = {ilvl = 463, upgradeLevel = 4, upgradeMax = 8},
+        [17] = {ilvl = 467, upgradeLevel = 1, upgradeMax = 6},
+        [18] = {ilvl = 467, upgradeLevel = 1, upgradeMax = 6},
+        [19] = {ilvl = 470, upgradeLevel = 2, upgradeMax = 6},
+        [20] = {ilvl = 470, upgradeLevel = 2, upgradeMax = 6},
+        [21] = {ilvl = 483, upgradeLevel = 6, upgradeMax = 6}, -- max rank from +20 loot
+        [22] = {ilvl = 489, upgradeLevel = 4, upgradeMax = 4} -- max rank for max vault loot
+    }
 
-        if lshPassedDifficulty == "Lfr" then
-            levelsBonusId = 1459
-        elseif lshPassedDifficulty == "normal" then
-            levelsBonusId = nil
-        elseif lshPassedDifficulty == "heroic" then
-            levelsBonusId = 1485
-        else
-            levelsBonusId = 1498
-        end
-        
-        local specIndex = GetSpecialization();
-        local specId = GetSpecializationInfo(specIndex)
+    local function GenerateTooltip(itemID, keyLevel)
+        local upgradeLevel = keyLevelInformation[keyLevel]["upgradeLevel"];
+        local upgradeMax = keyLevelInformation[keyLevel]["upgradeMax"];
+        local itemLevel = keyLevelInformation[keyLevel]["ilvl"];
+        local tooltipData = C_TooltipInfo.GetItemKey(itemID, itemLevel, 0)
 
-        local itemId = id .. ":"
-        local enchantID = ":"
-        local gemID1 = ":"
-        local gemID2 = ":"
-        local gemID3 = ":"
-        local gemID4 = ":"
-        local suffixID = ":"
-        local uniqueID = ":"
-        local linkLevel = "50:"
-        local specializationID = specId .. ":"
-        local modifiersMask = ":"
-        local itemContext = "22:"
-        local numBonusIDs;
-        if levelsBonusId ~= nil then
-            numBonusIDs = "1:" .. levelsBonusId
-        else
-            numBonusIDs = ":"
+        if keyLevel == 21 then
+            keyLevel = 20
+        elseif keyLevel == 22 then
+            keyLevel = "Vault"
         end
-        local numModifiers = ":"
-        local relic1NumBonusIDs= ":"
-        local relic2NumBonusIDs = ":"
-        local relic3NumBonusIDs = ":"
-        local crafterGUID = ":"
-        local extraEnchantID = ":"
-        local itemLink2 = "|cffa335ee|Hitem:"..itemId..enchantID..gemID1..gemID2..gemID3..gemID4..suffixID..uniqueID..linkLevel..specializationID..modifiersMask..itemContext..numBonusIDs..numModifiers..relic1NumBonusIDs..relic2NumBonusIDs..relic3NumBonusIDs..crafterGUID..extraEnchantID
-        itemLink2 = itemLink2.."|h[" .. name .. "]|h|r"
-        return itemLink2
+    
+        tooltipData.lines[1].leftColor = ITEM_QUALITY_COLORS[Enum.ItemQuality.Epic].color
+        table.insert(tooltipData.lines, 2, {
+          type = 0,
+          leftText = PLAYER_DIFFICULTY_MYTHIC_PLUS .. " " .. keyLevel,
+          leftColor = GREEN_FONT_COLOR,
+        })
+        table.insert(tooltipData.lines, 4, {
+          type = 0,
+          leftText = ITEM_UPGRADE_TOOLTIP_FORMAT:format(upgradeLevel, upgradeMax),
+          leftColor = NORMAL_FONT_COLOR,
+        })
+        for index, line in ipairs(tooltipData.lines) do
+          if line.leftText == AUCTION_HOUSE_BUCKET_VARIATION_EQUIPMENT_TOOLTIP then
+            table.remove(tooltipData.lines, index)
+            table.remove(tooltipData.lines, index - 1)
+            break
+          end
+        end
+        local info = {
+          tooltipData = tooltipData,
+        }
+        GameTooltip:ProcessInfo(info)
+        GameTooltip:Show()
     end
 
     local lsh_spec_counter = 1;
+    -- for each individual specs table of loot
     for _,v in pairs(specTables) do
         local lsh_lootItemCounter = 0;
         for _,_ in pairs(v) do
@@ -1226,6 +1674,7 @@ function displaySpecLoot(specTables, sharedTable, passedInstanceType)
             individualSpecContainer:SetTitle(lsh_spec_name);
             scrollContainer:AddChild(individualSpecContainer);
 
+            --for each item in the specs table
             for key, value in pairs(v) do
                 if passedInstanceType == "raid" then
                     for targetKey, targetValue in pairs(targetedItemsRaid) do
@@ -1243,8 +1692,7 @@ function displaySpecLoot(specTables, sharedTable, passedInstanceType)
                                 if ( (IsModifiedClick("COMPAREITEMS") or GetCVarBool("alwaysCompareItems")) ) then
                                     GameTooltip_ShowCompareItem(GameTooltip)
                                 end
-                                local linkForToolTip = buildLink(targetValue["itemId"],targetValue["name"], lsh_thisDifficult)
-                                GameTooltip:SetHyperlink(linkForToolTip)
+                                GameTooltip:SetHyperlink(targetValue["link"])
                             end)
                             targetItem:SetCallback("OnLeave", function(widget) GameTooltip:FadeOut() end)
                             individualSpecContainer:AddChild(targetItem);
@@ -1253,8 +1701,10 @@ function displaySpecLoot(specTables, sharedTable, passedInstanceType)
                         end
                     end
                 elseif passedInstanceType == "dungeon" then
+                    -- match with targeted item
                     for targetKey, targetValue in pairs(targetedItemsDungeon) do
-                        if targetValue["itemId"] == value then
+                        -- if targetValue is the same item
+                        if targetValue["name"] == value then
                             local targetItem = AceGUI:Create("InteractiveLabel");
                             targetItem:SetText(targetValue["name"]);
                             targetItem:SetImage(GetItemIcon(targetValue["itemId"]));
@@ -1264,8 +1714,11 @@ function displaySpecLoot(specTables, sharedTable, passedInstanceType)
                                 if ( (IsModifiedClick("COMPAREITEMS") or GetCVarBool("alwaysCompareItems")) ) then
                                     GameTooltip_ShowCompareItem(GameTooltip)
                                 end
-                                GameTooltip:SetHyperlink("item:" .. targetValue["itemId"])
+                                local item = Item:CreateFromItemID(targetValue["itemId"])
+                                item:ContinueOnItemLoad(function()
+                                    GenerateTooltip(targetValue["itemId"], targetValue["level"])
                                 end)
+                            end)
                             targetItem:SetCallback("OnLeave", function(widget) GameTooltip:FadeOut() end)
                             individualSpecContainer:AddChild(targetItem);
                             break
@@ -1297,16 +1750,17 @@ function displaySpecLoot(specTables, sharedTable, passedInstanceType)
         sharedSpecContainer:SetTitle("Shared Spec Loot");
         scrollContainer:AddChild(sharedSpecContainer);
 
+        -- for each item that is in the shared table
         for key, value in pairs(sharedTable) do
             if passedInstanceType == "raid" then
                 for targetKey, targetValue in pairs(targetedItemsRaid) do
-                    if targetValue["itemId"] == value then
+                    if (targetValue["itemId"] == value) and (targetValue["difficulty"] == lsh_thisDifficult) then
                         local targetItem = AceGUI:Create("InteractiveLabel");
                         lsh_thisDifficult = GetDifficultyInfo(GetRaidDifficultyID())
                         if lsh_thisDifficult == "Looking For Raid" then
                             lsh_thisDifficult = "Lfr"
                         end
-                        targetItem:SetText(targetValue["name"] .. " - " .. lsh_thisDifficult);
+                        targetItem:SetText(targetValue["name"] .. " - " .. lsh_thisDifficult); -- this adds currently difficulty, but ilvl in tooltip is lowest
                         targetItem:SetImage(GetItemIcon(targetValue["itemId"]));
                         targetItem:SetImageSize(50,50);
                         targetItem:SetCallback("OnEnter", function(widget)
@@ -1318,8 +1772,7 @@ function displaySpecLoot(specTables, sharedTable, passedInstanceType)
                             if lsh_this_raidDiff == "Looking For Raid" then
                                 lsh_this_raidDiff = "Lfr"
                             end
-                            local linkForToolTip = buildLink(targetValue["itemId"],targetValue["name"], lsh_this_raidDiff)
-                            GameTooltip:SetHyperlink(linkForToolTip)
+                            GameTooltip:SetHyperlink(targetValue["link"])
                             end)
                         targetItem:SetCallback("OnLeave", function(widget) GameTooltip:FadeOut() end)
                         sharedSpecContainer:AddChild(targetItem);
@@ -1327,8 +1780,10 @@ function displaySpecLoot(specTables, sharedTable, passedInstanceType)
                     end
                 end
             elseif passedInstanceType == "dungeon" then
+                -- match with targeted item
                 for targetKey, targetValue in pairs(targetedItemsDungeon) do
-                    if (targetValue["itemId"] == value) then
+                    -- if targetValue is the same item
+                    if (targetValue["name"] == value) then
                         local targetItem = AceGUI:Create("InteractiveLabel");
                         targetItem:SetText(targetValue["name"]);
                         targetItem:SetImage(GetItemIcon(targetValue["itemId"]));
@@ -1338,7 +1793,10 @@ function displaySpecLoot(specTables, sharedTable, passedInstanceType)
                             if ( (IsModifiedClick("COMPAREITEMS") or GetCVarBool("alwaysCompareItems")) ) then
                                 GameTooltip_ShowCompareItem(GameTooltip)
                             end
-                            GameTooltip:SetHyperlink("item:" .. targetValue["itemId"])
+                            local item = Item:CreateFromItemID(targetValue["itemId"])
+                            item:ContinueOnItemLoad(function()
+                                GenerateTooltip(targetValue["itemId"], targetValue["level"])
+                            end)
                         end)
                         targetItem:SetCallback("OnLeave", function(widget) GameTooltip:FadeOut() end)
                         sharedSpecContainer:AddChild(targetItem);
@@ -1417,6 +1875,7 @@ function determineDropsForLootSpecs(passedEncounterId)
         EJ_SetLootFilter(lsh_class_id, lsh_spec_id)
         EJ_SelectEncounter(passedEncounterId)
         EJ_SetDifficulty(GetRaidDifficultyID())
+        C_EncounterJournal.ResetSlotFilter()
         index = 1
         while true do
             local itemId = C_EncounterJournal.GetLootInfoByIndex(index);
@@ -1490,21 +1949,17 @@ function checkTarget()
     --     print("targeted: " .. targetsName)
     -- end
     
-    --mostRecentBoss is the last encounter targeted which has loot that is targeted (starts as nil)
-
-    -- if there is a mostRecentBoss, we need to update the targetsName to be the correct encounterName
-    if mostRecentBoss ~= nil then
-        -- for UPDATE step 1, change these to new council/multiboss fights
-        if targetsName == "Scorchtail" then
-            targetsName = "Volcoross"
-        elseif targetsName == "Urctos" or targetsName == "Aerwynn" or targetsName == "Pip" then
-            targetsName = "Council of Dreams"
-        end
-
-        if mostRecentBoss == targetsName then
-            return
-        end
+    -- for UPDATE step 1, change these to new council/multiboss fights
+    if targetsName == "Pip" or targetsName == "Aerwynn" or targetsName == "Urctos" then
+        targetsName = "Council of Dreams"
+    elseif targetsName == "Scorchtail" then
+        targetsName = "Volcoross"
     end
+
+    if mostRecentBoss == targetsName then
+        return
+    end
+
     if globalSpecLootsFrame ~= nil then
         globalSpecLootsFrame:Release()
     end
@@ -1520,13 +1975,11 @@ function checkTarget()
         -- compareName is the name given from the loot table API
         local compareName = v["boss"]
         
-        --/run local data=C_TooltipInfo.GetHyperlink(format("unit:Creature-0-0-0-0-%d-0", 123456));print(data and data.lines[1].leftText or "not cached yet")
+        --/run local data=C_TooltipInfo.GetHyperlink(format("unit:Creature-0-0-0-0-%d-0", 189620));print(data and data.lines[1].leftText or "not cached yet")
         -- for UPDATE step 2, change these
         -- conditional from the LSH menu when adding an item
         -- new name from above line using npc ID instead of 123456 from wowhead
-        if (compareName == "Council of Dreams") then
-            compareName = "Urctos";
-        elseif (compareName == "Nymue, Weaver of the Cycle") then
+        if (compareName == "Nymue, Weaver of the Cycle") then
             compareName = "Nymue";
         elseif (compareName == "Tindral Sageswift, Seer of the Flame") then
             compareName = "Tindral Sageswift";

--- a/LootSpecHelper.toc
+++ b/LootSpecHelper.toc
@@ -1,7 +1,7 @@
 ## Interface: 100205
 ## Title: LootSpecHelper
 ## Author: Van
-## Version: 1.9
+## Version: 2.0
 ## SavedVariablesPerCharacter: targetedItemsRaid, targetedItemsDungeon
 ## IconTexture: Interface\AddOns\LootSpecHelper\Media\Icons\lshIcon.jpeg
 


### PR DESCRIPTION
- Updated dungeon loot to show proper ilvl while also allowing for dungeon levels of max hero rank or max vault rank.
- Added enable/disable checkbox and chat command to control targeted loot popups. Disabled status will not persist across logins
- Added reset button and chat command to allow for re-opening of targeted loot popups on a previously targeted boss or current dungeon
- Added targeted loot popup to end of dungeon run to allow for quick comparison of dropped items
- Added functionality to add/delete all above/below ranks. For example if you want an item from LFR Gnarlroot, safe to say you also want it from Normal, Heroic and Mythic and if you delete it from Mythic, you also do not want it from Heoric so that functionality is now built in when you delete one level, all below it also get deleted and when you add one level all above it get added. 
- Revamped entire UI to separate loot lists by Boss or Dungeon. Also moved add item button to the top of the list
- Updated raid popup to show ilvl in tooltip for the difficulty currently in


Important Notes:
- Newest version will require your current list to be entirely deleted and rebuilt to not have possible errors.